### PR TITLE
Fix use pointer cursor for clickable menu items

### DIFF
--- a/style.css
+++ b/style.css
@@ -479,6 +479,10 @@ ul.nav-menu > li {
 }
 
 
+ul.nav-menu > li:nth-child(n+2) {
+  cursor: pointer;
+}
+
 ul.nav-menu > li:nth-child(n+2):hover {
   background-color: hsl(0, 0%, 95%);
 }


### PR DESCRIPTION
The navigation bar has clickable items that do not use the pointer cursor. This fixes that.

Screenshot of problem: 
![bad-cursor](https://user-images.githubusercontent.com/3679678/64153984-37b6f500-ce30-11e9-9f0a-e30414b603d6.gif)
